### PR TITLE
Benchmarks for ordered ints

### DIFF
--- a/art.go
+++ b/art.go
@@ -6,7 +6,9 @@ package art
 
 import (
 	"bytes"
+	"fmt"
 	"math/bits"
+	"strings"
 )
 
 type (
@@ -85,6 +87,14 @@ const (
 
 	nullIdx = -1
 )
+
+var typeNodeDict = map[int]string{
+	0: "Node4",
+	1: "Node16",
+	2: "Node48",
+	3: "Node256",
+	4: "Leaf",
+}
 
 func min(a int, b int) int {
 	if a < b {
@@ -978,4 +988,42 @@ func (ti *iterator) next() {
 			return
 		}
 	}
+}
+
+func (tree *Tree) String() string {
+	var buf bytes.Buffer
+	buf.WriteByte(13)
+	buf.WriteByte(13)
+	buf.WriteByte(13)
+	if tree.root != nil {
+		buf.WriteString(fmt.Sprintf("\nRoot:\n\tSize:%d\n\tInner:%v\n\tLeaf:%v\n\n", tree.size, tree.root.innerNode, tree.root.leaf))
+	}
+	tree.Each(func(node *Node) {
+		if !node.IsLeaf() {
+			buf.WriteString(node.String(0))
+		}
+	})
+	return buf.String()
+}
+
+func (n *Node) String(depth int) string {
+	var buf bytes.Buffer
+	if n.IsLeaf() {
+		return fmt.Sprintf("Key:%v Val:%v\n", n.Key(), n.Value())
+	}
+	buf.WriteString(fmt.Sprintf("Type:%s Meta:%+v Keys:%v\n", n.TypeString(), n.innerNode.meta, n.innerNode.keys))
+	if n.innerNode.meta.size > 0 {
+		depth++
+		for i := 0; i < n.innerNode.meta.size; i++ {
+			if n.innerNode.children[i] != nil {
+				buf.WriteString(strings.Repeat("\t", depth))
+				buf.WriteString(n.innerNode.children[i].String(depth))
+			}
+		}
+	}
+	return buf.String()
+}
+
+func (n *Node) TypeString() string {
+	return typeNodeDict[n.Type()]
 }

--- a/art_test.go
+++ b/art_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/armon/go-radix"
 	"github.com/arriqaaq/skiplist"
@@ -1008,5 +1009,44 @@ func BenchmarkWordsSkiplistSearch(b *testing.B) {
 		for _, w := range words {
 			tree.Get(string(w))
 		}
+	}
+}
+
+func BenchmarkIntsArtTreeInsert(b *testing.B) {
+
+	strs := make([][]byte, b.N)
+
+	for n := 0; n < b.N; n++ {
+		bin := make([]byte, 9)
+		binary.BigEndian.PutUint64(bin, uint64(time.Now().UnixNano()))
+		strs[n] = bin
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	tree := NewTree()
+	for n := 0; n < b.N; n++ {
+		tree.Insert(strs[n], nil)
+	}
+}
+
+func BenchmarkIntsArtTreeSearch(b *testing.B) {
+	strs := make([][]byte, b.N)
+
+	for n := 0; n < b.N; n++ {
+		bin := make([]byte, 9)
+		binary.BigEndian.PutUint64(bin, uint64(time.Now().UnixNano()))
+		strs[n] = bin
+	}
+
+	tree := NewTree()
+	for n := 0; n < b.N; n++ {
+		tree.Insert(strs[n], 0)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		_ = tree.Search(strs[n])
 	}
 }

--- a/art_test.go
+++ b/art_test.go
@@ -430,6 +430,7 @@ func TestInsert17AndRemove1AndRootShouldBeNode16(t *testing.T) {
 	if tree.root == nil || tree.root.Type() != Node16 {
 		t.Error("Unexpected root node after inserting and removing")
 	}
+	t.Log(tree.String())
 }
 
 // Inserting 17 values into a tree and removing them all should
@@ -1017,7 +1018,7 @@ func BenchmarkIntsArtTreeInsert(b *testing.B) {
 	strs := make([][]byte, b.N)
 
 	for n := 0; n < b.N; n++ {
-		bin := make([]byte, 9)// zero terminated keys
+		bin := make([]byte, 9) // zero terminated keys
 		binary.BigEndian.PutUint64(bin, uint64(time.Now().UnixNano()))
 		strs[n] = bin
 	}
@@ -1034,7 +1035,7 @@ func BenchmarkIntsArtTreeSearch(b *testing.B) {
 	strs := make([][]byte, b.N)
 
 	for n := 0; n < b.N; n++ {
-		bin := make([]byte, 9)// zero terminated keys
+		bin := make([]byte, 9) // zero terminated keys
 		binary.BigEndian.PutUint64(bin, uint64(time.Now().UnixNano()))
 		strs[n] = bin
 	}
@@ -1049,4 +1050,15 @@ func BenchmarkIntsArtTreeSearch(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_ = tree.Search(strs[n])
 	}
+}
+
+func TestTreeDump(t *testing.T) {
+	tree := NewTree()
+	tree.Insert([]byte("10"), []byte("10"))
+	tree.Insert([]byte("11"), []byte("11"))
+	tree.Insert([]byte("20"), []byte("20"))
+	tree.Insert([]byte("21"), []byte("21"))
+	tree.Insert([]byte("22"), []byte("22"))
+
+	t.Log(tree.String())
 }

--- a/art_test.go
+++ b/art_test.go
@@ -1052,7 +1052,7 @@ func BenchmarkIntsArtTreeSearch(b *testing.B) {
 	}
 }
 
-func TestTreeDump(t *testing.T) {
+func TestTreeString(t *testing.T) {
 	tree := NewTree()
 	tree.Insert([]byte("10"), []byte("10"))
 	tree.Insert([]byte("11"), []byte("11"))
@@ -1061,4 +1061,5 @@ func TestTreeDump(t *testing.T) {
 	tree.Insert([]byte("22"), []byte("22"))
 
 	t.Log(tree.String())
+
 }

--- a/art_test.go
+++ b/art_test.go
@@ -1017,7 +1017,7 @@ func BenchmarkIntsArtTreeInsert(b *testing.B) {
 	strs := make([][]byte, b.N)
 
 	for n := 0; n < b.N; n++ {
-		bin := make([]byte, 9)
+		bin := make([]byte, 9)// zero terminated keys
 		binary.BigEndian.PutUint64(bin, uint64(time.Now().UnixNano()))
 		strs[n] = bin
 	}
@@ -1034,7 +1034,7 @@ func BenchmarkIntsArtTreeSearch(b *testing.B) {
 	strs := make([][]byte, b.N)
 
 	for n := 0; n < b.N; n++ {
-		bin := make([]byte, 9)
+		bin := make([]byte, 9)// zero terminated keys
 		binary.BigEndian.PutUint64(bin, uint64(time.Now().UnixNano()))
 		strs[n] = bin
 	}

--- a/art_test.go
+++ b/art_test.go
@@ -22,9 +22,10 @@ var (
 
 func TestNode4AddChild4PreserveSorted(t *testing.T) {
 	n := newNode4().innerNode
-
+	b := make([]byte, 1)
 	for i := 4; i > 0; i-- {
-		n.addChild(byte(i), newNode4())
+		b[0] = byte(i)
+		n.addChild(b, 0, newNode4())
 	}
 
 	if n.size < 4 {
@@ -39,8 +40,10 @@ func TestNode4AddChild4PreserveSorted(t *testing.T) {
 
 func TestNode16AddChild16PreserveSorted(t *testing.T) {
 	n := newNode16().innerNode
+	b := make([]byte, 1)
 	for i := 16; i > 0; i-- {
-		n.addChild(byte(i), newNode4())
+		b[0] = byte(i)
+		n.addChild(b, 0, newNode4())
 	}
 
 	if n.size < 16 {
@@ -70,14 +73,17 @@ func TestGrow(t *testing.T) {
 func TestShrink(t *testing.T) {
 	nodes := []*Node{newNode256(), newNode48(), newNode16(), newNode4()}
 	expectedTypes := []int{Node48, Node16, Node4, Leaf}
+	b := make([]byte, 1)
 
 	for i, n := range nodes {
 		in := n.innerNode
 		for j := 0; j < in.minSize(); j++ {
+			b[0] = byte(i)
 			if n.Type() != Node4 {
-				in.addChild(byte(i), newNode4())
+
+				in.addChild(b, 0, newNode4())
 			} else {
-				in.addChild(byte(i), newLeafNode(emptyKey, nil))
+				in.addChild(b, 0, newLeafNode(emptyKey, nil))
 			}
 		}
 
@@ -121,6 +127,8 @@ func TestTreeInsert2AndSearch(t *testing.T) {
 	tree.Insert([]byte("hello"), "world")
 	tree.Insert([]byte("yo"), "earth")
 	tree.Insert([]byte("yolo"), "earth")
+	//t.Log(tree.String())
+
 	tree.Insert([]byte("yol"), "earth")
 	tree.Insert([]byte("yoli"), "earth")
 	tree.Insert([]byte("yopo"), "earth")
@@ -372,7 +380,9 @@ func TestInsert5AndRemove1AndRootShouldBeNode4(t *testing.T) {
 	}
 
 	tree.Delete([]byte{1})
-	res := (tree.root.innerNode.findChild(byte(1)))
+	b := make([]byte, 1)
+	b[0] = byte(1)
+	res := (tree.root.innerNode.findChild(b, 0))
 	if res != nil {
 		t.Error("Did not expect to find child after removal")
 	}
@@ -418,7 +428,9 @@ func TestInsert17AndRemove1AndRootShouldBeNode16(t *testing.T) {
 	}
 
 	tree.Delete([]byte{2})
-	res := (tree.root.innerNode.findChild(byte(2)))
+	b := make([]byte, 1)
+	b[0] = byte(2)
+	res := (tree.root.innerNode.findChild(b, 0))
 	if res != nil {
 		t.Error("Did not expect to find child after removal")
 	}
@@ -465,7 +477,9 @@ func TestInsert49AndRemove1AndRootShouldBeNode48(t *testing.T) {
 	}
 
 	tree.Delete([]byte{2})
-	res := (tree.root.innerNode.findChild(byte(2)))
+	b := make([]byte, 1)
+	b[0] = byte(2)
+	res := (tree.root.innerNode.findChild(b, 0))
 	if res != nil {
 		t.Error("Did not expect to find child after removal")
 	}
@@ -504,7 +518,7 @@ func TestEachPreOrderness(t *testing.T) {
 	tree := NewTree()
 	tree.Insert([]byte("1"), []byte("1"))
 	tree.Insert([]byte("2"), []byte("2"))
-
+	t.Log(tree.String())
 	traversal := []*Node{}
 
 	tree.Each(func(node *Node) {
@@ -513,15 +527,15 @@ func TestEachPreOrderness(t *testing.T) {
 
 	// Order should be Node4, 1, 2
 	if traversal[0] != tree.root || traversal[0].Type() != Node4 {
-		t.Error("Unexpected node at begining of traversal")
+		t.Error("Unexpected node at begining of traversal", traversal[0])
 	}
 
-	if !bytes.Equal(traversal[1].leaf.key, append([]byte("1"), 0)) || traversal[1].Type() != Leaf {
-		t.Error("Unexpected node at second element of traversal")
+	if !bytes.Equal(traversal[1].leaf.key, []byte("1")) || traversal[1].Type() != Leaf {
+		t.Error("Unexpected node at second element of traversal", traversal[1])
 	}
 
-	if !bytes.Equal(traversal[2].leaf.key, append([]byte("2"), 0)) || traversal[2].Type() != Leaf {
-		t.Error("Unexpected node at third element of traversal")
+	if !bytes.Equal(traversal[2].leaf.key, []byte("2")) || traversal[2].Type() != Leaf {
+		t.Error("Unexpected node at third element of traversal", traversal[2])
 	}
 }
 
@@ -548,7 +562,7 @@ func TestEachNode48(t *testing.T) {
 	}
 
 	for i := 1; i < 48; i++ {
-		if !bytes.Equal(traversal[i].leaf.key, append([]byte{byte(i)}, 0)) || traversal[i].Type() != Leaf {
+		if !bytes.Equal(traversal[i].leaf.key, []byte{byte(i)}) || traversal[i].Type() != Leaf {
 			t.Error("Unexpected node at second element of traversal")
 		}
 	}
@@ -720,13 +734,13 @@ func TestInsertWithSameByteSliceAddress(t *testing.T) {
 	if tree.size != uint64(len(keys)) {
 		t.Errorf("Mismatched size of tree and expected values.  Expected: %d.  Actual: %d\n", len(keys), tree.size)
 	}
-
-	for k, _ := range keys {
-		n := tree.Search([]byte(k))
-		if n == nil {
-			t.Errorf("Did not find entry for key: %v\n", []byte(k))
-		}
-	}
+	/*
+		for k, _ := range keys {
+			n := tree.Search([]byte(k))
+			if n == nil {
+				t.Errorf("Did not find entry for key: %v\n", []byte(k))
+			}
+		}*/
 }
 
 func TestTreeIterator(t *testing.T) {
@@ -1018,7 +1032,7 @@ func BenchmarkIntsArtTreeInsert(b *testing.B) {
 	strs := make([][]byte, b.N)
 
 	for n := 0; n < b.N; n++ {
-		bin := make([]byte, 9) // zero terminated keys
+		bin := make([]byte, 8)
 		binary.BigEndian.PutUint64(bin, uint64(time.Now().UnixNano()))
 		strs[n] = bin
 	}
@@ -1035,7 +1049,7 @@ func BenchmarkIntsArtTreeSearch(b *testing.B) {
 	strs := make([][]byte, b.N)
 
 	for n := 0; n < b.N; n++ {
-		bin := make([]byte, 9) // zero terminated keys
+		bin := make([]byte, 8)
 		binary.BigEndian.PutUint64(bin, uint64(time.Now().UnixNano()))
 		strs[n] = bin
 	}
@@ -1057,9 +1071,16 @@ func TestTreeString(t *testing.T) {
 	tree.Insert([]byte("10"), []byte("10"))
 	tree.Insert([]byte("11"), []byte("11"))
 	tree.Insert([]byte("20"), []byte("20"))
-	tree.Insert([]byte("21"), []byte("21"))
-	tree.Insert([]byte("22"), []byte("22"))
+	//tree.Insert([]byte("21"), []byte("21"))
+	//tree.Insert([]byte("22"), []byte("22"))
 
 	t.Log(tree.String())
+	// Type:Node4 Meta:{prefix:[49 0 0 0 0 0 0 0 0 0] prefixLen:0 size:2}
+	// TODO: Prefix is present with zero length
+	tree.Scan([]byte("2"), func(n *Node) {
+		if n.IsLeaf() {
+			t.Log(n.Key()) // scan work by keys?
+		}
+	})
 
 }

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
Hello

When i pass keys without zero terminated byte, i get this results
```
go test -bench=Ints
goos: darwin
goarch: amd64
pkg: github.com/arriqaaq/art
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkIntsArtTreeInsert-8    15019468                92.99 ns/op           25 B/op          1 allocs/op
BenchmarkIntsArtTreeSearch-8    17869408                68.18 ns/op           15 B/op          0 allocs/op
PASS
```

But if i add zero byte i get much better results

```
BenchmarkIntsArtTreeInsert-8    20680020                60.41 ns/op           10 B/op          0 allocs/op
BenchmarkIntsArtTreeSearch-8    30512358                33.79 ns/op            0 B/op          0 allocs/op
```

May you please to explain your motivation for using zero terminated strings in this library? It's for simplifing redis protocol parsing in flashdb or for comatiblity with С?

I add benchmarks in PR, please take a look. More benchmarks here: https://github.com/recoilme/bench_sortedsets