### PR TITLE
Fix slice bounds out of range on prefix scan

### DIFF
--- a/art.go
+++ b/art.go
@@ -182,7 +182,10 @@ func (n *leafNode) IsMatch(key []byte) bool {
 }
 
 func (n *leafNode) isPrefixMatch(key []byte) bool {
-	return bytes.Equal(n.key[:len(key)], key)
+	if len(n.key) >= len(key[:]) {
+		return bytes.Equal(n.key[:len(key)], key)
+	}
+	return false
 }
 
 func (n *leafNode) prefixMatchIndex(leaf *leafNode, depth int) int {


### PR DESCRIPTION
Hi! 
PlayGround link - https://play.golang.com/p/QKIVw5fKdkz
In some cases (e.g. then search key length is too large) prefix scan output runtime error: slice bounds out of range.


```
package main

import (
	"fmt"
	"github.com/arriqaaq/art"
)

func main() {
	tree := art.NewTree()
	tree.Insert([]byte("test"), "value for test")
	tree.Insert([]byte("tester"), "value for tester")
	tree.Insert([]byte("testesteron"), "value for testesteron")
	leafFilter := func(n *art.Node) {
		if n.IsLeaf() {
			fmt.Println(string(n.Key()))
		}
	}
        // testersTest is too large then existing keys
	tree.Scan([]byte("testersTest"), leafFilter)
}
```

